### PR TITLE
FM-4: Group Messaging — CloudFunctions dependency client

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,10 @@ let package = Package(
             name: "Analytics",
             targets: ["Analytics"]
         ),
+        .library(
+            name: "CloudFunctions",
+            targets: ["CloudFunctions"]
+        ),
     ],
     dependencies: [
         .package(
@@ -77,6 +81,13 @@ let package = Package(
             name: "Analytics",
             dependencies: [
               .product(name: "FirebaseAnalytics", package: "firebase-ios-sdk"),
+              .product(name: "Dependencies", package: "swift-dependencies"),
+            ]
+        ),
+        .target(
+            name: "CloudFunctions",
+            dependencies: [
+              .product(name: "FirebaseFunctions", package: "firebase-ios-sdk"),
               .product(name: "Dependencies", package: "swift-dependencies"),
             ]
         )

--- a/Sources/CloudFunctions/CloudFunctionsClient.swift
+++ b/Sources/CloudFunctions/CloudFunctionsClient.swift
@@ -1,0 +1,32 @@
+//
+//  CloudFunctionsClient.swift
+//  fuoco
+//
+
+import Dependencies
+import FirebaseFunctions
+
+public struct CloudFunctionsClient: Sendable {
+    public var call: @Sendable (String, [String: Any]) async throws -> [String: Any]
+
+    public init(call: @escaping @Sendable (String, [String: Any]) async throws -> [String: Any]) {
+        self.call = call
+    }
+}
+
+extension CloudFunctionsClient: DependencyKey {
+    public static let liveValue = CloudFunctionsClient { name, params in
+        let functions = Functions.functions(region: "us-west1")
+        let result = try await functions.httpsCallable(name).call(params)
+        return result.data as? [String: Any] ?? [:]
+    }
+
+    public static let testValue = CloudFunctionsClient { _, _ in [:] }
+}
+
+extension DependencyValues {
+    public var cloudFunctions: CloudFunctionsClient {
+        get { self[CloudFunctionsClient.self] }
+        set { self[CloudFunctionsClient.self] = newValue }
+    }
+}


### PR DESCRIPTION
## Summary
New `CloudFunctions` library in the fuoco shared Swift package, wrapping Firebase Functions SDK with a TCA-compatible dependency client.

### What's added
- **`CloudFunctionsClient`** — Sendable struct with a single `call(name, params)` async method for invoking HTTPS callable Cloud Functions
- **`liveValue`** — Calls `Functions.functions(region: "us-west1").httpsCallable(name).call(params)`
- **`testValue`** — Returns empty dictionary (for TCA test stores)
- **`DependencyValues.cloudFunctions`** — Standard `@Dependency` accessor
- **Package.swift** — New library target with `FirebaseFunctions` + `swift-dependencies`

### Pattern
Follows the same structure as existing fuoco libraries (`Storage`, `Authentication`, `Analytics`):
```swift
@Dependency(\.cloudFunctions) var cloudFunctions
let result = try await cloudFunctions.call("createGroup", ["name": "Dawn Patrol", "memberIds": ids])
```

## Dependencies
Used by **foam** iOS app (bpdabrowski/foam#57) for group creation, add/remove member calls.

## Test plan
- [ ] `import CloudFunctions` compiles in foam iOS target
- [ ] `@Dependency(\.cloudFunctions)` resolves in reducers
- [ ] Live value successfully calls deployed Cloud Functions
- [ ] Test value returns empty dict without hitting network

🤖 Generated with [Claude Code](https://claude.com/claude-code)