### PR TITLE
Fix: Firestore listener uses full snapshots instead of deltas (FM-178)

### DIFF
--- a/Sources/Networking/FirestoreService.swift
+++ b/Sources/Networking/FirestoreService.swift
@@ -39,13 +39,12 @@ public final class FirestoreService: FirestoreServiceProtocol, Sendable {
                 if let error {
                     continuation.finish(throwing: error)
                 } else {
-                    let documents = querySnapshot?.documentChanges
-                        .filter { changeType.contains($0.type) }
-                        .compactMap { change -> T? in
+                    let documents = querySnapshot?.documents
+                        .compactMap { document -> T? in
                             do {
-                                var documentData = change.document.data()
+                                var documentData = document.data()
                                 if documentData["id"] == nil {
-                                    documentData["id"] = change.document.documentID
+                                    documentData["id"] = document.documentID
                                 }
                                 let data = try FirestoreParser.parse(
                                     documentData,


### PR DESCRIPTION
  - Switch FirestoreService.listener() from querySnapshot?.documentChanges to querySnapshot?.documents
  - documentChanges only returns the delta (changed docs), but consumers replace their entire state array with the result — wiping
  previously loaded data
  - Every listener consumer had this latent bug; now all callbacks return the complete document set

  Test plan

  - Verify surf reports persist in feed after new reports are added (no disappearing)
  - Verify any other listener-based views retain their data after updates